### PR TITLE
feat(frontend): add basic registration screen

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,8 @@
     "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "preact": "^10.5.14",
+        "preact-async-route": "^2.2.1",
+        "preact-router": "^3.2.1",
         "regenerator-runtime": "^0.13.7"
     }
 }

--- a/frontend/src/components/forms/button/style.scss
+++ b/frontend/src/components/forms/button/style.scss
@@ -33,7 +33,7 @@
 }
 
 .full {
-    width: 100%;
+    width: calc(100% - 8px);
     padding: 12px;
     justify-content: center;
 }

--- a/frontend/src/components/forms/horizontalSteps/index.tsx
+++ b/frontend/src/components/forms/horizontalSteps/index.tsx
@@ -1,0 +1,49 @@
+import { h, FunctionalComponent } from "preact";
+
+import * as style from "./style.scss";
+
+/**
+ * Render a horizontal step indicator.
+ * @param props The props to render with.
+ * @returns The JSX for the bar.
+ */
+export const HorizontalSteps: FunctionalComponent<Props> = (props) => {
+    const clickListener = (item: number) => {
+        if (!props.onClick) return;
+        if (item >= props.activeStep) return;
+
+        props.onClick(item);
+    };
+
+    let items = [];
+    const itemWidth = `${(1 / props.stepCount) * 100}%`;
+
+    for (let i = 1; i <= props.stepCount; i++) {
+        const active = props.activeStep === i ? style.active : "";
+        const clickable =
+            props.onClick && i < props.activeStep ? style.clickable : "";
+        const classes = `${active} ${clickable}`;
+
+        const item = (
+            <li
+                class={classes}
+                style={{ width: itemWidth }}
+                key={i}
+                onClick={() => clickListener(i)}
+            />
+        );
+        items.push(item);
+    }
+
+    return <ul class={style.bar}>{items}</ul>;
+};
+
+interface Props {
+    // Amount of steps in the bar.
+    stepCount: number;
+    // Current active step.
+    // This is one indexed, so if there are 3 steps, the last active step is `3`.
+    activeStep: number;
+
+    onClick?: (item: number) => void;
+}

--- a/frontend/src/components/forms/horizontalSteps/style.scss
+++ b/frontend/src/components/forms/horizontalSteps/style.scss
@@ -1,0 +1,61 @@
+.bar {
+    margin: 0;
+    padding: 0;
+}
+
+.bar li {
+    position: relative;
+    list-style-type: none;
+    float: left;
+    margin: 12px 0;
+    font-size: 12px;
+    width: auto;
+
+    &:before {
+        width: 16px;
+        height: 16px;
+        content: "";
+        border: 2px solid var(--highlight-secondary);
+        display: block;
+        text-align: center;
+        margin: 0 auto;
+        border-radius: 16px;
+        position: relative;
+        z-index: 20;
+        background: var(--highlight-text);
+    }
+
+    &:after {
+        width: 100%;
+        height: 2px;
+        content: "";
+        position: absolute;
+        background: var(--highlight-secondary);
+        top: 8px;
+        left: -50%;
+        z-index: 0;
+    }
+
+    &:first-child:after {
+        width: 50%;
+        content: none;
+    }
+
+    &.active {
+        color: var(--highlight-primary);
+        font-weight: bold;
+
+        &:before {
+            border-color: var(--highlight-secondary);
+            background: var(--highlight-primary);
+        }
+    }
+}
+
+.clickable {
+    cursor: pointer;
+
+    &:hover:before {
+        background: var(--highlight-primary);
+    }
+}

--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -1,3 +1,4 @@
 export { Button } from "./button";
+export { HorizontalSteps } from "./horizontalSteps";
 export { IconButton } from "./iconButton";
 export { TextInput } from "./textInput";

--- a/frontend/src/components/forms/textInput/index.tsx
+++ b/frontend/src/components/forms/textInput/index.tsx
@@ -21,7 +21,7 @@ export const TextInput: FunctionalComponent<Props> = (props) => {
             <label for={props.id}>{props.title}</label>
             <input
                 id={props.id}
-                value={input}
+                value={props.value || input}
                 placeholder={props.placeholder}
                 type={props.type || "text"}
                 disabled={props.disabled}
@@ -42,6 +42,7 @@ interface Props {
     autocomplete?:
         | "off"
         | "on"
+        | "name"
         | "username"
         | "new-password"
         | "current-password";
@@ -49,6 +50,8 @@ interface Props {
     type?: "password" | "search" | "email" | "text";
     // If this input is disabled.
     disabled?: boolean;
+    // The value of the input, if regulated upstream.
+    value?: string;
 
     // Change event of the input.
     onInput?: (newValue: string) => void;

--- a/frontend/src/components/forms/textInput/style.scss
+++ b/frontend/src/components/forms/textInput/style.scss
@@ -13,7 +13,7 @@
     input {
         font-size: 16px;
         padding: 8px 8px;
-        color: var(--text-subscript);
+        color: var(--text-regular);
         background: none;
         border-radius: 4px;
         border: 1px solid var(--text-subscript);

--- a/frontend/src/pages/authenticate/index.tsx
+++ b/frontend/src/pages/authenticate/index.tsx
@@ -1,10 +1,11 @@
 import { h, FunctionalComponent } from "preact";
 import { faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
 
+import Router from "preact-router";
+import AsyncRoute from "preact-async-route";
+
 import { IconButton } from "/src/components/forms";
 import { AvailableThemes, useTheme } from "/src/components/theme";
-
-import { Login } from "./login";
 
 import * as style from "./style.scss";
 
@@ -36,7 +37,21 @@ export const Auth: FunctionalComponent = () => {
                         onClick={() => switchTheme()}
                     />
                 </span>
-                <Login />
+                <Router>
+                    <AsyncRoute
+                        path="/auth/login"
+                        getComponent={() =>
+                            import("./login").then((f) => f["Login"])
+                        }
+                    />
+                    <AsyncRoute
+                        default
+                        path="/auth/register"
+                        getComponent={() =>
+                            import("./register").then((f) => f["Register"])
+                        }
+                    />
+                </Router>
             </div>
         </div>
     );

--- a/frontend/src/pages/authenticate/register/authStep.tsx
+++ b/frontend/src/pages/authenticate/register/authStep.tsx
@@ -1,0 +1,83 @@
+import { h, FunctionalComponent, Fragment } from "preact";
+import { useMemo, useState } from "preact/hooks";
+import {
+    faAsterisk,
+    faKey,
+    faStepBackward,
+} from "@fortawesome/free-solid-svg-icons";
+
+import { Button, TextInput } from "/src/components/forms";
+import { Icon } from "/src/components/media";
+import { Divider } from "/src/components/layout";
+
+import * as style from "./style.scss";
+
+/**
+ * Authentication provide step of the registration procedure.
+ * @param props Props to render the step with.
+ * @returns The JSX for the step.
+ */
+export const AuthStep: FunctionalComponent<Props> = (props) => {
+    const [password, setPassword] = useState("");
+    const [repeatedPassword, setRepeatedPassword] = useState("");
+
+    const isPasswordValid = useMemo(() => {
+        if (password.length < 3) return false;
+        if (password !== repeatedPassword) return false;
+
+        return true;
+    }, [password, repeatedPassword]);
+
+    return (
+        <Fragment>
+            <TextInput
+                id="password"
+                title="Password"
+                type="password"
+                autocomplete="new-password"
+                placeholder="hunter123"
+                onInput={(password) => setPassword(password)}
+            />
+            <TextInput
+                id="repeatpassword"
+                title="Repeat Password"
+                type="password"
+                autocomplete="new-password"
+                placeholder="hunter123"
+                onInput={(password) => setRepeatedPassword(password)}
+            />
+            <Button
+                alt="Register with an Password"
+                full
+                disabled={!isPasswordValid}
+            >
+                <Icon icon={faAsterisk} pad />
+                Register with Password
+            </Button>
+            <Divider text="or" />
+            <Button alt="Register with WebAuthn" full>
+                <Icon icon={faKey} pad />
+                Register with WebAuthn
+            </Button>
+            <div class={style.bottombutton}>
+                <Button
+                    alt="Go back"
+                    full
+                    secondary
+                    onClick={() => props.changeStep(props.step - 1)}
+                >
+                    <Icon icon={faStepBackward} pad />
+                    Go Back
+                </Button>
+            </div>
+        </Fragment>
+    );
+};
+
+interface Props {
+    // The current step.
+    step: number;
+
+    // Change the current step.
+    changeStep: (newStep: number) => void;
+}

--- a/frontend/src/pages/authenticate/register/index.tsx
+++ b/frontend/src/pages/authenticate/register/index.tsx
@@ -1,0 +1,58 @@
+import { h, FunctionalComponent } from "preact";
+import { useState } from "preact/hooks";
+
+import { HorizontalSteps } from "/src/components/forms";
+
+import { NameStep } from "./nameStep";
+import { AuthStep } from "./authStep";
+
+/**
+ * Register screen.
+ * Includes multiple steps, which are not routed.
+ * @returns The JSX of the registration screen.
+ */
+export const Register: FunctionalComponent = () => {
+    const [step, setStep] = useState(1);
+    const [name, setName] = useState("");
+    const [username, setUsername] = useState("");
+
+    const changeStep = (newStep: number) => {
+        setStep(newStep);
+    };
+
+    let stepComponent = <div>asdasd</div>;
+
+    if (step === 1) {
+        stepComponent = (
+            <NameStep
+                name={name}
+                username={username}
+                setName={setName}
+                setUsername={setUsername}
+                step={step}
+                changeStep={changeStep}
+            />
+        );
+    } else if (step === 2) {
+        stepComponent = <AuthStep step={step} changeStep={changeStep} />;
+    }
+
+    return (
+        <main>
+            <h2>Welcome! Let's Get Started!</h2>
+            <h4>
+                Or{" "}
+                <a href="/auth/login" alt="Login">
+                    login
+                </a>{" "}
+                instead.
+            </h4>
+            <HorizontalSteps
+                stepCount={2}
+                activeStep={step}
+                onClick={(i) => changeStep(i)}
+            />
+            {stepComponent}
+        </main>
+    );
+};

--- a/frontend/src/pages/authenticate/register/nameStep.tsx
+++ b/frontend/src/pages/authenticate/register/nameStep.tsx
@@ -1,0 +1,72 @@
+import { h, FunctionalComponent, Fragment } from "preact";
+import { useMemo } from "preact/hooks";
+import { faStepForward } from "@fortawesome/free-solid-svg-icons";
+
+import { Button, TextInput } from "/src/components/forms";
+import { Icon } from "/src/components/media";
+
+import * as style from "./style.scss";
+
+/**
+ * Component for the names step of the registration procedure.
+ * @param props Props to render the step with.
+ * @returns The JSX of the component.
+ */
+export const NameStep: FunctionalComponent<Props> = (props) => {
+    const isValid = useMemo(() => {
+        if (props.name.length < 3) return false;
+        if (props.username.length < 3) return false;
+        if (!/^([a-z]|[A-Z]|[0-9]|[-_.]){3,}$/.test(props.username))
+            return false;
+
+        return true;
+    }, [props.name, props.username]);
+
+    return (
+        <Fragment>
+            <TextInput
+                id="fullname"
+                title="Full Name"
+                autocomplete="name"
+                placeholder="John Doe"
+                value={props.name}
+                onInput={(username) => props.setName(username)}
+            />
+            <TextInput
+                id="username"
+                title="Username"
+                autocomplete="username"
+                placeholder="John.Doe42"
+                value={props.username}
+                onInput={(username) => props.setUsername(username)}
+            />
+            <div class={style.bottombutton}>
+                <Button
+                    alt="Go to the next step"
+                    full
+                    disabled={!isValid}
+                    onClick={() => props.changeStep(props.step + 1)}
+                >
+                    <Icon icon={faStepForward} pad />
+                    Next Step
+                </Button>
+            </div>
+        </Fragment>
+    );
+};
+
+interface Props {
+    // The current name set.
+    name: string;
+    // The current username set.
+    username: string;
+    // The current step.
+    step: number;
+
+    // Change the current step.
+    changeStep: (newStep: number) => void;
+    // Set the name
+    setName: (newName: string) => void;
+    // Set the username
+    setUsername: (newUsername: string) => void;
+}

--- a/frontend/src/pages/authenticate/register/style.scss
+++ b/frontend/src/pages/authenticate/register/style.scss
@@ -1,0 +1,3 @@
+.bottombutton {
+    margin-top: 18px;
+}


### PR DESCRIPTION
Add basic screen to register. This will then later be used to add the registration logic.

Closes #8.